### PR TITLE
Added HashMap/Map type support for Dart bindings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ members = [
     "fixtures/metadata",
     "fixtures/simple-iface",
     "fixtures/streams_ext",
+    "fixtures/simple-fns",
     #"fixtures/*",
 ]
 

--- a/src/gen/compounds.rs
+++ b/src/gen/compounds.rs
@@ -183,3 +183,112 @@ impl_code_type_for_compound!(SequenceCodeType, "List<{}>", "Sequence{}");
 
 impl_renderable_for_compound!(OptionalCodeType, "{}?", "FfiConverterOptional{}");
 impl_renderable_for_compound!(SequenceCodeType, "FfiConverterSequence{}");
+
+// Map<K, V>
+#[derive(Debug)]
+pub struct MapCodeType {
+    self_type: Type,
+    key: Type,
+    value: Type,
+}
+
+impl MapCodeType {
+    pub fn new(self_type: Type, key: Type, value: Type) -> Self {
+        Self {
+            self_type,
+            key,
+            value,
+        }
+    }
+
+    fn key(&self) -> &Type {
+        &self.key
+    }
+
+    fn value(&self) -> &Type {
+        &self.value
+    }
+}
+
+impl CodeType for MapCodeType {
+    fn type_label(&self) -> String {
+        format!(
+            "Map<{}, {}>",
+            DartCodeOracle::find(self.key()).type_label(),
+            DartCodeOracle::find(self.value()).type_label()
+        )
+    }
+
+    fn canonical_name(&self) -> String {
+        let key = DartCodeOracle::find(self.key()).canonical_name();
+        let val = DartCodeOracle::find(self.value()).canonical_name();
+        format!("Map{}To{}", key, val)
+    }
+}
+
+impl Renderable for MapCodeType {
+    fn render_type_helper(&self, type_helper: &dyn TypeHelperRenderer) -> dart::Tokens {
+        type_helper.include_once_check(&self.ffi_converter_name(), &self.self_type);
+
+        let key_codetype = DartCodeOracle::find(self.key());
+        let val_codetype = DartCodeOracle::find(self.value());
+
+        type_helper.include_once_check(&key_codetype.canonical_name(), self.key());
+        type_helper.include_once_check(&val_codetype.canonical_name(), self.value());
+
+        let cl_name = &self.ffi_converter_name();
+        let key_type_label_owned = key_codetype.type_label();
+        let val_type_label_owned = val_codetype.type_label();
+        let key_type_label = &key_type_label_owned;
+        let val_type_label = &val_type_label_owned;
+
+        let key_conv_owned = key_codetype.ffi_converter_name();
+        let val_conv_owned = val_codetype.ffi_converter_name();
+        let key_conv = &key_conv_owned;
+        let val_conv = &val_conv_owned;
+
+        quote! {
+            class $cl_name {
+                static Map<$key_type_label, $val_type_label> lift(RustBuffer buf) {
+                    return $cl_name.read(buf.asUint8List()).value;
+                }
+
+                static LiftRetVal<Map<$key_type_label, $val_type_label>> read(Uint8List buf) {
+                    final map = <$key_type_label, $val_type_label>{};
+                    final length = buf.buffer.asByteData(buf.offsetInBytes).getInt32(0);
+                    int offset = buf.offsetInBytes + 4;
+                    for (var i = 0; i < length; i++) {
+                        final k = $key_conv.read(Uint8List.view(buf.buffer, offset));
+                        offset += k.bytesRead;
+                        final v = $val_conv.read(Uint8List.view(buf.buffer, offset));
+                        offset += v.bytesRead;
+                        map[k.value] = v.value;
+                    }
+                    return LiftRetVal(map, offset - buf.offsetInBytes);
+                }
+
+                static int write(Map<$key_type_label, $val_type_label> value, Uint8List buf) {
+                    buf.buffer.asByteData(buf.offsetInBytes).setInt32(0, value.length);
+                    int offset = buf.offsetInBytes + 4;
+                    for (final entry in value.entries) {
+                        offset += $key_conv.write(entry.key, Uint8List.view(buf.buffer, offset));
+                        offset += $val_conv.write(entry.value, Uint8List.view(buf.buffer, offset));
+                    }
+                    return offset - buf.offsetInBytes;
+                }
+
+                static int allocationSize(Map<$key_type_label, $val_type_label> value) {
+                    return value.entries
+                        .map((e) => $key_conv.allocationSize(e.key) + $val_conv.allocationSize(e.value))
+                        .fold(4, (a, b) => a + b);
+                }
+
+                static RustBuffer lower(Map<$key_type_label, $val_type_label> value) {
+                    final buf = Uint8List(allocationSize(value));
+                    write(value, buf);
+                    return toRustBuffer(buf);
+                }
+            }
+        }
+    }
+}

--- a/src/gen/oracle.rs
+++ b/src/gen/oracle.rs
@@ -688,6 +688,15 @@ impl<T: AsType> AsCodeType for T {
                 self.as_type(),
                 *inner_type,
             )),
+            Type::Map {
+                key_type,
+                value_type,
+                ..
+            } => Box::new(compounds::MapCodeType::new(
+                self.as_type(),
+                *key_type,
+                *value_type,
+            )),
             Type::Enum { name, .. } => Box::new(enums::EnumCodeType::new(name)),
             Type::Record { name, .. } => Box::new(records::RecordCodeType::new(name)),
             Type::CallbackInterface { name, .. } => Box::new(

--- a/src/gen/render/mod.rs
+++ b/src/gen/render/mod.rs
@@ -94,6 +94,14 @@ impl<T: AsType> AsRenderable for T {
                 self.as_type(),
                 *inner_type,
             )),
+            Type::Map {
+                key_type,
+                value_type,
+            } => Box::new(compounds::MapCodeType::new(
+                self.as_type(),
+                *key_type,
+                *value_type,
+            )),
             Type::Enum { name, .. } => Box::new(enums::EnumCodeType::new(name)),
             Type::Record { name, .. } => Box::new(records::RecordCodeType::new(name)),
             Type::Custom {


### PR DESCRIPTION
- Implemented map type generation in compounds.rs
- Add map type handling to oracle.rs for type resolution and validation
- Update render module to support map type code generation and output
- Enable HashMap<K,V> and Map<K,V> types in Dart FFI bindings
- Support nested map types and complex key-value pair structures
- Enable simple-fns fixture in workspace for testing