### PR TITLE
Default to temporary directories with configurable output options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,5 @@ og-fixtures/*
 rust-toolchain.toml
 internal_todo.md
 ISSUES.md
-.tmp_tests/
 convert_fixtures.sh
 .DS_Store


### PR DESCRIPTION
- Use camino-tempfile::tempdir by default with automatic cleanup
- Add TestConfig for full control over test execution
- Support env overrides: UNIFFI_DART_TEST_DIR, UNIFFI_DART_NO_DELETE, UNIFFI_DART_FAILURE_DELAY
- Resolve relative custom dirs against workspace root
- Preserve temp files when no-delete is set (uses std::mem::forget)
- Remove .tmp_tests references and folder - temp dirs are cleaner by default

Backwards compatible: existing run_test() continues to work.