### PR TITLE
Fix enum-variant class names that collide with a same-named type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ members = [
     "fixtures/dart_async",
     "fixtures/proc-macro",
     "fixtures/proc-macro-no-implicit-prelude",
+    "fixtures/enum_variant_collision",
     #"fixtures/*",
 ]
 

--- a/fixtures/enum_variant_collision/Cargo.toml
+++ b/fixtures/enum_variant_collision/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "enum_variant_collision"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+name = "enum_variant_collision"
+crate-type = ["lib", "cdylib"]
+
+[dependencies]
+uniffi = { workspace = true, features = ["build"] }
+
+[build-dependencies]
+uniffi-dart = { path = "../../", features = ["build"] }
+
+[dev-dependencies]
+uniffi-dart = { path = "../../", features = ["bindgen-tests"] }
+uniffi = { workspace = true, features = ["bindgen-tests"] }
+anyhow = "1"

--- a/fixtures/enum_variant_collision/build.rs
+++ b/fixtures/enum_variant_collision/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    uniffi_dart::generate_scaffolding("./src/api.udl".into()).unwrap();
+}

--- a/fixtures/enum_variant_collision/src/api.udl
+++ b/fixtures/enum_variant_collision/src/api.udl
@@ -1,0 +1,1 @@
+namespace enum_variant_collision { };

--- a/fixtures/enum_variant_collision/src/lib.rs
+++ b/fixtures/enum_variant_collision/src/lib.rs
@@ -1,0 +1,42 @@
+// Regression fixture: a data-carrying enum variant's Dart class is named
+// `{Variant}{Enum}`. When that equals a real top-level type name, the generator
+// used to emit two same-named Dart classes — a Dart compile error. The generator
+// now disambiguates the variant class with a `Variant` suffix, looping past any
+// further collision, against the names of every type that emits a top-level class
+// (records, enums, objects, callback interfaces).
+
+#[derive(uniffi::Record, Clone, PartialEq, Debug)]
+pub struct FieldCondition {
+    key: String,
+}
+
+// Forces a SECOND-ORDER collision: the `Field` variant's base name
+// `FieldCondition` clashes with the record above, so it is suffixed to
+// `FieldConditionVariant` — which clashes with THIS record, so the generator must
+// keep going (`FieldConditionVariant2`). A one-shot suffix would emit a duplicate.
+#[derive(uniffi::Record, Clone, PartialEq, Debug)]
+pub struct FieldConditionVariant {
+    note: String,
+}
+
+// A flat enum whose name equals the `Kind` variant's `{Kind}{Condition}` class,
+// exercising the enum branch of the reserved-name set.
+#[derive(uniffi::Enum, PartialEq, Debug)]
+pub enum KindCondition {
+    A,
+    B,
+}
+
+#[derive(uniffi::Enum, PartialEq, Debug)]
+pub enum Condition {
+    Field { condition: FieldCondition },
+    Kind { kind: KindCondition },
+    Plain { value: i32 },
+}
+
+#[uniffi::export]
+pub fn roundtrip_condition(c: Condition) -> Condition {
+    c
+}
+
+uniffi::include_scaffolding!("api");

--- a/fixtures/enum_variant_collision/test/enum_variant_collision_test.dart
+++ b/fixtures/enum_variant_collision/test/enum_variant_collision_test.dart
@@ -1,0 +1,27 @@
+import 'package:test/test.dart';
+import '../enum_variant_collision.dart';
+
+void main() {
+  test('record collision, looping past a second-order clash, round-trips', () {
+    // `Field` -> base `FieldCondition` (record) -> `FieldConditionVariant`
+    // (also a record) -> `FieldConditionVariant2`. Round-trips through both the
+    // variant class's lower/write and the FfiConverter's `read` dispatch.
+    final c = FieldConditionVariant2(FieldCondition(key: "k"));
+    final out = roundtripCondition(c: c);
+    expect(out, isA<FieldConditionVariant2>());
+    expect((out as FieldConditionVariant2).condition.key, "k");
+  });
+
+  test('collision with an enum type is disambiguated (enum branch of reserved set)', () {
+    // `Kind` -> base `KindCondition` (a flat enum) -> `KindConditionVariant`.
+    final c = KindConditionVariant(KindCondition.a);
+    final out = roundtripCondition(c: c);
+    expect(out, isA<KindConditionVariant>());
+    expect((out as KindConditionVariant).kind, KindCondition.a);
+  });
+
+  test('non-colliding variant is unaffected', () {
+    final out = roundtripCondition(c: PlainCondition(42));
+    expect((out as PlainCondition).value, 42);
+  });
+}

--- a/fixtures/enum_variant_collision/tests/mod.rs
+++ b/fixtures/enum_variant_collision/tests/mod.rs
@@ -1,0 +1,6 @@
+use anyhow::Result;
+
+#[test]
+fn enum_variant_collision() -> Result<()> {
+    uniffi_dart::testing::run_test("enum_variant_collision", "src/api.udl", None)
+}

--- a/src/gen/enums.rs
+++ b/src/gen/enums.rs
@@ -156,12 +156,53 @@ pub fn generate_enum(obj: &Enum, type_helper: &dyn TypeHelperRenderer) -> dart::
             false
         }
 
+        // A data-carrying variant's Dart class is named `{Variant}{Enum}`, which
+        // can collide with a real top-level type of the same name (e.g. enum
+        // `Condition` variant `Field` -> `FieldCondition`, clashing with a record
+        // `FieldCondition`). Collect the names of every type that emits a
+        // top-level Dart class so a colliding variant class can be disambiguated
+        // instead of emitted twice. (Custom types lower to a typedef/converter,
+        // not a class of that name, so they are deliberately excluded.)
+        let reserved_type_names: std::collections::HashSet<String> = {
+            let ci = type_helper.get_ci();
+            ci.record_definitions()
+                .iter()
+                .map(|d| DartCodeOracle::class_name(d.name()))
+                .chain(ci.enum_definitions().iter().map(|d| DartCodeOracle::class_name(d.name())))
+                .chain(ci.object_definitions().iter().map(|d| DartCodeOracle::class_name(d.name())))
+                .chain(
+                    ci.callback_interface_definitions()
+                        .iter()
+                        .map(|d| DartCodeOracle::class_name(d.name())),
+                )
+                .collect()
+        };
+
+        // Name a data-carrying variant's Dart class `{Variant}{Enum}`, suffixing
+        // on collision so it doesn't clash with a same-named top-level type (a
+        // duplicate declaration). Used both where the class is defined and where
+        // the FfiConverter's `read` dispatches to it, so the two stay in sync.
+        let variant_class_name = |variant_name: &str| -> String {
+            let base = format!("{}{}", DartCodeOracle::class_name(variant_name), dart_cls_name);
+            if !reserved_type_names.contains(&base) {
+                return base;
+            }
+            // Loop rather than suffix once: a type literally named `{base}Variant`
+            // would otherwise reintroduce the very duplicate this guards against.
+            let mut candidate = format!("{base}Variant");
+            let mut n = 2;
+            while reserved_type_names.contains(&candidate) {
+                candidate = format!("{base}Variant{n}");
+                n += 1;
+            }
+            candidate
+        };
+
         for (index, variant_obj) in obj.variants().iter().enumerate() {
             for f in variant_obj.fields() {
                 type_helper.include_once_check(&f.as_codetype().canonical_name(), &f.as_type());
             }
-            let variant_dart_cls_name =
-                &format!("{}{}", DartCodeOracle::class_name(variant_obj.name()), dart_cls_name);
+            let variant_dart_cls_name = &variant_class_name(variant_obj.name());
 
             // Prepare constructor parameters
             let constructor_params = variant_obj
@@ -346,7 +387,7 @@ pub fn generate_enum(obj: &Enum, type_helper: &dyn TypeHelperRenderer) -> dart::
                     switch(index) {
                         $(for (index, variant) in obj.variants().iter().enumerate() =>
                         case $(index + 1):
-                            final lifted = $(format!("{}{}", DartCodeOracle::class_name(variant.name()), dart_cls_name)).read(subview);
+                            final lifted = $(variant_class_name(variant.name())).read(subview);
                             return LiftRetVal<$dart_cls_name>(lifted.value, lifted.bytesRead - subview.offsetInBytes + 4);
                         )
                         default:  throw UniffiInternalError(UniffiInternalError.unexpectedEnumCase, "Unable to determine enum variant");


### PR DESCRIPTION
### Problem

A data-carrying enum variant is rendered as a Dart class named `{Variant}{Enum}`. When that concatenation equals a real top-level type name, the generated file contains **two declarations with the same name** — a Dart compile error.

Concrete case (reduced from a real crate):

```rust
#[derive(uniffi::Record)]
pub struct FieldCondition { key: String }

#[derive(uniffi::Enum)]
pub enum Condition {
    Field { condition: FieldCondition },  // -> Dart class `FieldCondition`
}
```

The `Field` variant of `Condition` becomes `class FieldCondition extends Condition`, clashing with the `FieldCondition` record. `dart analyze` then reports `duplicate_definition` (and the FfiConverter's `read` dispatch calls `.read` on the wrong class). The same happens for a `Named` variant over a `NamedVector` type, etc.

### Fix

Collect the top-level type names (records / enums / objects) and, **only on collision**, suffix the variant class with `Variant` (`FieldConditionVariant`). Non-colliding variants are unchanged, so existing generated APIs are untouched.

The name is produced by a single shared closure used **both** where the variant class is defined and where the enum's FfiConverter `read` dispatches to it — the two computed the name independently before, so fixing only the definition site left a dangling `.read` reference.

### Test

Adds an `enum_variant_collision` fixture reproducing the clash (`Condition::Field` + record `FieldCondition`). It fails to compile without the fix (duplicate class) and round-trips with it. `cargo test -p enum_variant_collision` is green.

### Note

Includes a small `chore` commit dropping a redundant `&` in a few `format!`/`println!` args — stable clippy 1.97+ added `redundant reference in format! argument`, which fails `cargo clippy -- -D warnings` on the current `Testing` CI for pre-existing code. Needed for green CI here; harmless to drop on rebase if it lands elsewhere first.
