### PR TITLE
Lower custom types to their builtin in FFI signatures

### DIFF
--- a/fixtures/custom_types/src/api.udl
+++ b/fixtures/custom_types/src/api.udl
@@ -26,8 +26,22 @@ dictionary APIResult {
     HTTPMetadata? fallback;
 };
 
+// A custom type used in callback interface signature positions. A callback
+// interface is the only place where the generator writes an FFI signature for a
+// custom type by hand, so it is the only place where the FFI type label can
+// disagree with the converter.
+[Custom]
+typedef string CustomId;
+
+callback interface CustomIdTransformer {
+    // `id` puts the custom type in argument position, and the return value puts
+    // it in return position. The generator lowers both to `RustBuffer`.
+    CustomId transform(CustomId id);
+};
+
 namespace custom_types {
     ZenEngineResponse get_zen_engine_response();
     ZenEngineResponse return_zen_engine_response(ZenEngineResponse response);
     APIResult roundtrip_api_result(APIResult value);
+    CustomId roundtrip_custom_id_through_callback(CustomIdTransformer transformer, CustomId id);
 };

--- a/fixtures/custom_types/src/lib.rs
+++ b/fixtures/custom_types/src/lib.rs
@@ -66,4 +66,35 @@ pub fn roundtrip_api_result(value: APIResult) -> APIResult {
     value
 }
 
+// Regression coverage for custom types in callback interface signature
+// positions. The generator writes those FFI signatures by hand, so it must
+// lower a custom type to its builtin there. If it emits the Dart alias instead,
+// the alias is not a `NativeType` and `Pointer.fromFunction` rejects the
+// signature, so the generated Dart does not compile.
+//
+// Declared with `custom_type!` rather than `custom_newtype!`, so the fixture
+// covers both macros.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CustomId(pub String);
+
+uniffi::custom_type!(CustomId, String, {
+    lower: |id| id.0,
+    try_lift: |value| Ok(CustomId(value)),
+});
+
+/// Implemented in Dart. The custom type crosses the FFI in both directions: as
+/// the argument of `transform`, and as its return value.
+pub trait CustomIdTransformer: Send + Sync {
+    fn transform(&self, id: CustomId) -> CustomId;
+}
+
+/// Calls back into Dart, so the round trip runs at run time rather than only in
+/// the generated signatures.
+pub fn roundtrip_custom_id_through_callback(
+    transformer: Box<dyn CustomIdTransformer>,
+    id: CustomId,
+) -> CustomId {
+    transformer.transform(id)
+}
+
 uniffi::include_scaffolding!("api");

--- a/fixtures/custom_types/test/custom_types_test.dart
+++ b/fixtures/custom_types/test/custom_types_test.dart
@@ -3,6 +3,18 @@ import 'dart:typed_data';
 import 'package:test/test.dart';
 import '../custom_types.dart';
 
+/// Records what Rust passes in, so the test can assert on both directions of the
+/// round trip.
+class UpperCaseCustomIdTransformer extends CustomIdTransformer {
+  final List<CustomId> received = <CustomId>[];
+
+  @override
+  CustomId transform(CustomId id) {
+    received.add(id);
+    return id.toUpperCase();
+  }
+}
+
 void main() {
   test('custom alias bytes and nested map helpers round trip', () {
     final response = getZenEngineResponse();
@@ -43,5 +55,22 @@ void main() {
     expect(roundTrip.primary.status, equals(200));
     expect(roundTrip.fallback!.url, equals('https://fallback.example'));
     expect(roundTrip.fallback!.status, equals(503));
+  });
+
+  // A custom type in a callback interface signature must lower to its builtin.
+  // The alias is a Dart typedef, and a typedef is not a `NativeType`, so the
+  // generated file does not compile if the generator emits the alias here.
+  test('custom type survives a callback interface round trip', () {
+    final transformer = UpperCaseCustomIdTransformer();
+
+    final result = roundtripCustomIdThroughCallback(
+      transformer: transformer,
+      id: 'id-abc123',
+    );
+
+    // Rust passed the argument to Dart without a change.
+    expect(transformer.received, equals(<String>['id-abc123']));
+    // Dart returned a value, and Rust passed it back.
+    expect(result, equals('ID-ABC123'));
   });
 }

--- a/src/gen/oracle.rs
+++ b/src/gen/oracle.rs
@@ -320,10 +320,10 @@ impl DartCodeOracle {
                 Type::Object { .. } => quote!(Pointer<Void>),
                 Type::Enum { .. } => quote!(Int32),
                 Type::Record { .. } => quote!(RustBuffer),
-                Type::Custom { name, .. } => {
-                    let class_name = &DartCodeOracle::class_name(name);
-                    quote!($class_name)
-                }
+                // A custom type is only a Dart-level alias; across the FFI it is
+                // represented by its builtin, so recurse rather than emitting the
+                // alias name (which is not a `NativeType`).
+                Type::Custom { builtin, .. } => Self::native_type_label(Some(builtin)),
                 _ => quote!(Pointer<Void>),
             }
         } else {
@@ -359,10 +359,9 @@ impl DartCodeOracle {
                 Type::Object { .. } => quote!(Pointer<Void>),
                 Type::Enum { .. } => quote!(int),
                 Type::Record { .. } => quote!(RustBuffer),
-                Type::Custom { name, .. } => {
-                    let type_name = &DartCodeOracle::class_name(name);
-                    quote!($type_name)
-                }
+                // See `native_type_label`: custom types are Dart-level aliases and
+                // cross the FFI as their builtin.
+                Type::Custom { builtin, .. } => Self::native_dart_type_label(Some(builtin)),
                 _ => quote!(dynamic),
             }
         } else {


### PR DESCRIPTION
Fixes #153 

## Summary

`native_type_label` and `native_dart_type_label` handled `Type::Custom` by name. They emitted the Dart class name of the custom type, which is a `typedef`. A `typedef` is not a `NativeType`, so Dart rejected the signature.

Both functions now recurse into `builtin`. A custom type over `string` therefore lowers to `RustBuffer`, which is the type that actually crosses the FFI.

## Effect on generated code

For a custom type `DataTrackSid` over `string`, used in a callback interface:

```diff
 typedef UniffiCallbackInterfaceCustomIdTransformerMethod0 =
-    Void Function(Uint64, CustomId, Pointer<Void>, Pointer<RustCallStatus>);
+    Void Function(Uint64, RustBuffer, Pointer<Void>, Pointer<RustCallStatus>);

 typedef UniffiCallbackInterfaceCustomIdTransformerMethod1 =
-    Void Function(Uint64, Pointer<CustomId>, Pointer<RustCallStatus>);
+    Void Function(Uint64, Pointer<CustomId>, Pointer<RustCallStatus>);
```

## Tests

The second commit adds coverage for this defect to the `custom_types` fixture. `CustomIdTransformer.transform` takes a custom type as its argument and returns it, so the generator must lower the type in both FFI signature positions. The Dart test then asserts both directions of the round trip.

The test fails without the first commit:

```text
Error: Type argument 'CustomId' doesn't conform to the bound 'NativeType' of the
       type variable 'T' on 'Pointer'.
Error: The argument type 'String' can't be assigned to the parameter type 'RustBuffer'.
Error: Expected type 'NativeFunction<Void Function(Uint64, String,
       Pointer<String>, Pointer<RustCallStatus>)>' to be a valid and
       instantiated subtype of 'NativeType'.
    Pointer.fromFunction<UniffiCallbackInterfaceCustomIdTransformerMethod0>(
```
