### PR TITLE
Use monotonic clock and inclusive lower bounds in dart_async test

### DIFF
--- a/fixtures/dart_async/test/futures_test.dart
+++ b/fixtures/dart_async/test/futures_test.dart
@@ -2,10 +2,10 @@ import 'package:test/test.dart';
 import '../dart_async.dart';
 
 Future<Duration> measureTime(Future<void> Function() action) async {
-  final start = DateTime.now();
+  final stopwatch = Stopwatch()..start();
   await action();
-  final end = DateTime.now();
-  return end.difference(start);
+  stopwatch.stop();
+  return stopwatch.elapsed;
 }
 
 // The DELAY-based timing assertions below check a LOWER bound only: that an
@@ -93,7 +93,7 @@ void main() {
       await sleep(ms: 200);
     });
 
-    expect(time.inMilliseconds > 200, true);
+    expect(time.inMilliseconds >= 200, true);
   });
 
   test('sequential_future', () async {
@@ -103,7 +103,7 @@ void main() {
       expect(resultAlice, 'Hello, Alice!');
       expect(resultBob, 'Hello, Bob!');
     });
-    expect(time.inMilliseconds > 300, true);
+    expect(time.inMilliseconds >= 300, true);
   });
 
   test('concurrent_future', () async {
@@ -153,7 +153,7 @@ void main() {
       final resultAlice = await sayAfterWithTokio(ms: 200, who: 'Alice');
       expect(resultAlice, 'Hello, Alice (with Tokio)!');
     });
-    expect(time.inMilliseconds > 200, true);
+    expect(time.inMilliseconds >= 200, true);
   });
 
   test('fallible_function_and_method', () async {


### PR DESCRIPTION
## What
- targeting the flaky async time tests
- `measureTime` now uses a monotonic `Stopwatch` instead of `DateTime.now()`.
- The three lower-bound assertions that used a strict `>` now use `>=`, like the rest of the file.

## Why

`DateTime.now()` is the wall clock. NTP can slew or step it on a CI runner during a measurement, so the interval it reports can be shorter than the time that actually elapsed. Rust's `thread::sleep` never returns early, so the lower-bound failure on #149 (`sleep(200)` measured as `<= 200ms`) can only come from the clock, not from the code under test.

A sleep of exactly N ms also truncates to N milliseconds, which fails a strict bound. Two of the three strict bounds sit on a single sleep, so this is latent on any fast runner.

Refs #139.

🤖 Generated with [Claude Code](https://claude.com/claude-code)